### PR TITLE
Added user-error handling system for providers.

### DIFF
--- a/src/providers/LocalProvider.ts
+++ b/src/providers/LocalProvider.ts
@@ -1,18 +1,71 @@
-import Provider from "./Provider";
+import Provider, { ErrorHandler as BaseErrorHandler } from './Provider';
 
-import type { Request } from 'express';
+import type { Request, Response, NextFunction } from 'express';
 
-type Handler = (username: string | null, password: string | null) => Promise<Express.User>;
+type RequestHandler = (
+	username: unknown,
+	password: unknown
+) => Express.User | Promise<Express.User> | Error;
 
-class LocalProvider extends Provider<Handler> {
-	public async process(req: Request) {
-		const { username, password } = req.body as Record<string, unknown>;
-		
-		if (typeof username !== 'string' || typeof password !== 'string') {
-			throw new Error('username or password have the wrong type or are undefined');
+export class IncorrectCredentials extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = this.constructor.name;
+	}
+}
+type ErrorHandler = BaseErrorHandler<IncorrectCredentials>;
+
+interface Options {
+	failureRedirect: string
+}
+
+function createErrorHandlerFromOptions(options: Options): ErrorHandler | null {
+	if (Object.keys(options).length <= 0) return null;
+
+	return (req, res) => {
+		if (options.failureRedirect) {
+			res.redirect(301, options.failureRedirect);
+		}
+	};
+}
+
+class LocalProvider extends Provider<RequestHandler, ErrorHandler> {
+	constructor(requestHandler: RequestHandler, errorHandlerOrOptions?: ErrorHandler | Options) {
+		let errorHandler;
+		let options;
+
+		if (typeof errorHandlerOrOptions === 'function') {
+			errorHandler = errorHandlerOrOptions;
+		} else if (typeof errorHandlerOrOptions === 'object') {
+			options = errorHandlerOrOptions;
+			errorHandler = createErrorHandlerFromOptions(options);
 		}
 
-		const processedUser = await this.handler(username, password);
+		super(requestHandler, errorHandler);
+	}
+
+	public async process(req: Request, res: Response, next: NextFunction) {
+		const { username, password } = req.body as Record<string, unknown>;
+
+		const requestHandlerResult = await this.requestHandler(username, password);
+
+		if (requestHandlerResult instanceof Error) {
+			const error = requestHandlerResult;
+
+			// In case there's no error handler defined, pass it on to Express
+			if (typeof this.errorHandler !== 'function') {
+				return next(error);
+			}
+
+			if (error instanceof IncorrectCredentials) {
+				this.errorHandler(req, res, error);
+			}
+
+			// If not a LocalProvider custom error, pass it on to Express to handle
+			return next(error);
+		}
+
+		const processedUser = requestHandlerResult;
 		return processedUser;
 	}
 }

--- a/src/providers/Provider.ts
+++ b/src/providers/Provider.ts
@@ -1,17 +1,33 @@
-import type { Request, Response } from 'express';
+import type { Request, Response, NextFunction } from 'express';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-type BaseHandler = (...args: any[]) => Promise<Express.User>;
+export type RequestHandler = (...args: any[]) => Express.User | Promise<Express.User> | Error;
 
-export abstract class Provider<Handler extends BaseHandler = BaseHandler> {
-	// Processes request and returns user
-	protected handler: Handler;
+//? TODO: Should the return type of an ErrorHandler by void or could it be another error (one passed on to Express)?
+/*
+ * Error handler that can handle the errors included in the `PotentialErrors` type.
+ */
+export type ErrorHandler<PotentialErrors> = (req: Request, res: Response, error: PotentialErrors) => void;
 
-	constructor(handler: Handler) {
-		this.handler = handler;
+export abstract class Provider<
+	CustomRequestHandler extends RequestHandler = RequestHandler,
+	CustomErrorHandler extends ErrorHandler<never> = ErrorHandler<never>
+> {
+	/**
+	* Middleware that processes the request and returns a `Promise<Express.User> | Express.User` or an `Error` object
+	*/
+	protected requestHandler: CustomRequestHandler;
+	/**
+	* Handles custom errors returned by the requestHandler
+	*/
+	protected errorHandler?: CustomErrorHandler;
+
+	constructor(requestHandler: CustomRequestHandler, errorHandler?: CustomErrorHandler | null) {
+		this.requestHandler = requestHandler;
+		if (errorHandler !== null) this.errorHandler = errorHandler;
 	}
 
-	public abstract process(req: Request, res: Response): Express.User | Promise<Express.User>;
+	public abstract process(req: Request, res: Response, next: NextFunction): Express.User | Promise<Express.User>;
 }
 
 export default Provider;


### PR DESCRIPTION
Custom errors are designed and exported by each Provider. Each provider can define its own errorHandler function, which allows the user to handle the custom errors that appeared while processing the request.

The provider can do anything it wants with the errorHandler (which could facilitate its end-user use) as long as it sticks to the base definitions of ErrorHandler found in the file that contains the Provider base class.